### PR TITLE
Support jms-3 in filtermanagerbundle v2.1

### DIFF
--- a/DependencyInjection/Compiler/FilterPass.php
+++ b/DependencyInjection/Compiler/FilterPass.php
@@ -88,7 +88,8 @@ class FilterPass implements CompilerPassInterface
                     new Reference('jms_serializer')
                 ]
             );
-
+            $managerDefinition->setPublic(true);
+            
             $container->setDefinition(ONGRFilterManagerExtension::getFilterManagerId($managerName), $managerDefinition);
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,14 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/symfony": "~3.0",
-        "ongr/elasticsearch-bundle": "~5.0",
-        "jms/serializer-bundle": "^2.0"
+        "handcraftedinthealps/elasticsearch-bundle": "^5.0",
+        "jms/serializer-bundle": "^2.4 || ^3.0",
+        "symfony/twig-bundle": "^3.4|^4.0",
+        "symfony/translation": "^3.4|^4.0",
+        "symfony/asset": "^3.4|^4.0",
+        "twig/twig": "^2",
+        "symfony/browser-kit": "^3.4|^4.0",
+        "symfony/css-selector": "^3.4|^4.0"
     },
     "require-dev": {
         "monolog/monolog": "~1.0",


### PR DESCRIPTION
We already used the support-jms-3-in-2.1 branch in production. I want to add more changes in our own 2.x releases of the FilterManagerBundle as https://github.com/handcraftedinthealps/ElasticsearchBundle is not compatible with https://github.com/ongr-io/FilterManagerBundle anymore